### PR TITLE
RadioDld.Properties.Settings.StorePath added

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -14,3 +14,6 @@ Sorting in favourites list
 
 ### Nick Sharples
 Original proof of concept code for RSS server
+
+### Boris Ockham
+Optional path to the database in .config

--- a/Classes/Database.cs
+++ b/Classes/Database.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of Radio Downloader.
- * Copyright © 2007-2012 by the authors - see the AUTHORS file for details.
+ * Copyright © 2007-2016 by the authors - see the AUTHORS file for details.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -19,6 +19,7 @@
 namespace RadioDld
 {
     using System;
+    using System.Configuration;
     using System.Data.SQLite;
     using System.Drawing;
     using System.IO;
@@ -44,7 +45,13 @@ namespace RadioDld
         {
             if (dbConn == null)
             {
-                dbConn = new SQLiteConnection("Data Source=" + Path.Combine(FileUtils.GetAppDataFolder(), "store.db") + ";Version=3;New=False");
+                string storePath = ConfigurationManager.AppSettings["RadioDld.Properties.Settings.StorePath"];
+                if (string.IsNullOrEmpty(storePath) || !File.Exists(storePath))
+                {
+                    storePath = Path.Combine(FileUtils.GetAppDataFolder(), "store.db");
+                }
+
+                dbConn = new SQLiteConnection("Data Source=" + storePath + ";Version=3;New=False");
                 dbConn.Open();
             }
 

--- a/app.config
+++ b/app.config
@@ -9,4 +9,9 @@
         <supportedRuntime version="v2.0.50727"/>
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0"/>
     </startup>
+    <!-- If store.db is not in de default location and/or the name is different,
+         the value of RadioDld.Properties.Settings.StorePath should reflect this fact. -->
+    <appSettings>
+      <add key="RadioDld.Properties.Settings.StorePath" value="" />
+    </appSettings>
 </configuration>


### PR DESCRIPTION
Radio Downloader.exe.config now contains RadioDld.Properties.Settings.StorePath. When filled with an existing path to a copy of the database store.db, this database will be opened, not the default one.

In the future this setting might be taken as a command to create store.db at that location and with that name by parsing the string for the requested name of the database.