### PR TITLE
Solution for conforming alphabetical order downloads with downloaded order

### DIFF
--- a/Classes/Model/Download.cs
+++ b/Classes/Model/Download.cs
@@ -456,7 +456,9 @@ namespace RadioDld.Model
             while (Directory.GetFiles(saveDir, Path.GetFileName(savePath) + ".*").Length > 0 &&
                    savePath != currentFileName)
             {
-                savePath = rootName + " (" + Convert.ToString(diffNum, CultureInfo.CurrentCulture) + ")";
+                // The first file will have the name "xxxx" and the next "xxxx1"
+                // this way the alphabetical order is the same as the downloaded order.
+                savePath = rootName + Convert.ToString(diffNum, CultureInfo.CurrentCulture);
                 diffNum += 1;
             }
 


### PR DESCRIPTION
Because I copy the downloads of podcasts to an mp3-player I need the alphabetical order to be the same as the downloaded order, even when the dates of the podcasts are the same. One easy way to do this is to add " (0)" to the file name format. Because of the current change this will result in the name of the first file to be "xxxx (0)" and the second "xxxx (1)", etc.

Renaming an original "xxxx" to "xxxx (0)" when "xxxx (1)" has to be saved, would be better. One problem however is that FindFreeSaveFileName doesn't use one explicit extension. So you don't know what the filename is that has to be renamed. Beside this problem there are more consequences of renaming an already downloaded file.

To make something like {epnumber} work is much more involved than the current change.