### PR TITLE
Settings optionally differentiated by programme

### DIFF
--- a/Classes/DownloadHandler.cs
+++ b/Classes/DownloadHandler.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of Radio Downloader.
- * Copyright © 2007-2014 by the authors - see the AUTHORS file for details.
+ * Copyright © 2007-2016 by the authors - see the AUTHORS file for details.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -190,7 +190,7 @@ namespace RadioDld
 
                 try
                 {
-                    saveLocation = FileUtils.GetSaveFolder();
+                    saveLocation = FileUtils.GetSaveFolder(this.progInfo);
                 }
                 catch (DirectoryNotFoundException)
                 {
@@ -209,7 +209,7 @@ namespace RadioDld
 
                 try
                 {
-                    finalName = Model.Download.FindFreeSaveFileName(Settings.FileNameFormat, this.progInfo, this.episodeInfo, saveLocation);
+                    finalName = Model.Download.FindFreeSaveFileName(Settings.GetFileNameFormat(this.progInfo), this.progInfo, this.episodeInfo, saveLocation);
                 }
                 catch (IOException ioExp)
                 {
@@ -256,26 +256,27 @@ namespace RadioDld
                 Model.Programme.SetLatestDownload(this.progInfo.Progid, this.episodeInfo.Date);
             }
 
+            string runAfterCommand = Settings.GetRunAfterCommand(this.progInfo);
+            if (!string.IsNullOrEmpty(runAfterCommand))
+            {
+                try
+                {
+                    // Use VB Interaction.Shell as Process.Start doesn't give the option of a non-focused window
+                    // The "comspec" environment variable gives the path to cmd.exe
+                    Microsoft.VisualBasic.Interaction.Shell("\"" + Environment.GetEnvironmentVariable("comspec") + "\" /c " + runAfterCommand.Replace("%file%", finalName), Microsoft.VisualBasic.AppWinStyle.NormalNoFocus);
+                }
+                catch
+                {
+                    // Just ignore the error, as it just means that something has gone wrong with the run after command.
+                }
+            }
+
             // Remove single episode subscriptions
             if (Model.Subscription.IsSubscribed(this.progInfo.Progid))
             {
                 if (this.progInfo.SingleEpisode)
                 {
                     Model.Subscription.Remove(this.progInfo.Progid);
-                }
-            }
-
-            if (!string.IsNullOrEmpty(Settings.RunAfterCommand))
-            {
-                try
-                {
-                    // Use VB Interaction.Shell as Process.Start doesn't give the option of a non-focused window
-                    // The "comspec" environment variable gives the path to cmd.exe
-                    Microsoft.VisualBasic.Interaction.Shell("\"" + Environment.GetEnvironmentVariable("comspec") + "\" /c " + Settings.RunAfterCommand.Replace("%file%", finalName), Microsoft.VisualBasic.AppWinStyle.NormalNoFocus);
-                }
-                catch
-                {
-                    // Just ignore the error, as it just means that something has gone wrong with the run after command.
                 }
             }
 

--- a/Classes/FileUtils.cs
+++ b/Classes/FileUtils.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of Radio Downloader.
- * Copyright © 2007-2012 by the authors - see the AUTHORS file for details.
+ * Copyright © 2007-2016 by the authors - see the AUTHORS file for details.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -24,20 +24,20 @@ namespace RadioDld
 
     internal static class FileUtils
     {
-        public static string GetSaveFolder()
+        public static string GetSaveFolder(Model.Programme progInfo)
         {
             const string DefaultFolder = "Downloaded Radio";
 
-            string saveFolder;
+            string saveFolder = Settings.SetSaveFolder(progInfo);
 
-            if (!string.IsNullOrEmpty(Settings.SaveFolder))
+            if (!string.IsNullOrEmpty(saveFolder))
             {
-                if (!new DirectoryInfo(Settings.SaveFolder).Exists)
+                if (!new DirectoryInfo(saveFolder).Exists)
                 {
                     throw new DirectoryNotFoundException();
                 }
 
-                return Settings.SaveFolder;
+                return saveFolder;
             }
 
             try

--- a/Classes/Settings.cs
+++ b/Classes/Settings.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of Radio Downloader.
- * Copyright © 2007-2014 by the authors - see the AUTHORS file for details.
+ * Copyright © 2007-2016 by the authors - see the AUTHORS file for details.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -26,45 +26,6 @@ namespace RadioDld
 
     public class Settings : Database
     {
-        internal static string SaveFolder
-        {
-            get
-            {
-                return GetValue("SaveFolder");
-            }
-
-            set
-            {
-                SetValue("SaveFolder", value);
-            }
-        }
-
-        internal static string FileNameFormat
-        {
-            get
-            {
-                return GetValue("FileNameFormat", "%epname% %day%-%month%-%year%");
-            }
-
-            set
-            {
-                SetValue("FileNameFormat", value);
-            }
-        }
-
-        internal static string RunAfterCommand
-        {
-            get
-            {
-                return GetValue("RunAfterCommand");
-            }
-
-            set
-            {
-                SetValue("RunAfterCommand", value);
-            }
-        }
-
         internal static DateTime LastUpdatePrompt
         {
             get
@@ -369,6 +330,36 @@ namespace RadioDld
             }
         }
 
+        internal static string SetSaveFolder(Model.Programme progInfo)
+        {
+            return GetValuePostfix(progInfo, "SaveFolder", null);
+        }
+
+        internal static void SetSaveFolder(Model.Programme progInfo, string value)
+        {
+            SetValuePostfix(progInfo, "SaveFolder", value);
+        }
+
+        internal static string GetFileNameFormat(Model.Programme progInfo)
+        {
+            return GetValuePostfix(progInfo, "FileNameFormat", "%epname% %day%-%month%-%year%");
+        }
+
+        internal static void SetFileNameFormat(Model.Programme progInfo, string value)
+        {
+            SetValuePostfix(progInfo, "FileNameFormat", value);
+        }
+
+        internal static string GetRunAfterCommand(Model.Programme progInfo)
+        {
+            return GetValuePostfix(progInfo, "RunAfterCommand", null);
+        }
+
+        internal static void SetRunAfterCommand(Model.Programme progInfo, string value)
+        {
+            SetValuePostfix(progInfo, "RunAfterCommand", value);
+        }
+
         internal static void ResetUserSettings()
         {
             SetValue("RunOnStartup", null);
@@ -489,6 +480,33 @@ namespace RadioDld
                     }
                 }
             }
+        }
+
+        private static string GetValuePostfix(Model.Programme progInfo, string name, string defaultValue)
+        {
+            string value = null;
+            if (progInfo != null)
+            {
+                value = GetValue(name + progInfo.Progid.ToString(CultureInfo.InvariantCulture));
+            }
+
+            if (string.IsNullOrEmpty(value))
+            {
+                value = GetValue(name, defaultValue);
+            }
+
+            return value;
+        }
+
+        private static void SetValuePostfix(Model.Programme progInfo, string name, string value)
+        {
+            string postfix = string.Empty;
+            if (progInfo != null)
+            {
+                postfix = progInfo.Progid.ToString(CultureInfo.InvariantCulture);
+            }
+
+            SetValue(name = postfix, value);
         }
     }
 }

--- a/Forms/Preferences.cs
+++ b/Forms/Preferences.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of Radio Downloader.
- * Copyright © 2007-2015 by the authors - see the AUTHORS file for details.
+ * Copyright © 2007-2016 by the authors - see the AUTHORS file for details.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -58,7 +58,7 @@ namespace RadioDld
                 return;
             }
 
-            bool formatChanged = Settings.FileNameFormat != this.TextFileNameFormat.Text;
+            bool formatChanged = Settings.GetFileNameFormat(null) != this.TextFileNameFormat.Text;
 
             if (this.folderChanged || formatChanged)
             {
@@ -86,12 +86,12 @@ namespace RadioDld
                     }
                 }
 
-                Settings.SaveFolder = this.TextSaveIn.Text;
-                Settings.FileNameFormat = this.TextFileNameFormat.Text;
+                Settings.SetSaveFolder(null, this.TextSaveIn.Text);
+                Settings.SetFileNameFormat(null, this.TextFileNameFormat.Text);
             }
 
             Settings.RunOnStartup = this.CheckRunOnStartup.Checked;
-            Settings.RunAfterCommand = this.TextRunAfter.Text;
+            Settings.SetRunAfterCommand(null, this.TextRunAfter.Text);
             Settings.ParallelDownloads = (int)this.NumberParallel.Value;
             Settings.RssServer = this.CheckRssServer.Checked;
 
@@ -145,15 +145,15 @@ namespace RadioDld
 
             try
             {
-                this.TextSaveIn.Text = FileUtils.GetSaveFolder();
+                this.TextSaveIn.Text = FileUtils.GetSaveFolder(null);
             }
             catch (DirectoryNotFoundException)
             {
-                this.TextSaveIn.Text = Settings.SaveFolder;
+                this.TextSaveIn.Text = Settings.SetSaveFolder(null);
             }
 
-            this.TextFileNameFormat.Text = Settings.FileNameFormat;
-            this.TextRunAfter.Text = Settings.RunAfterCommand;
+            this.TextFileNameFormat.Text = Settings.GetFileNameFormat(null);
+            this.TextRunAfter.Text = Settings.GetRunAfterCommand(null);
         }
 
         private void Preferences_HelpButtonClicked(object sender, System.ComponentModel.CancelEventArgs e)


### PR DESCRIPTION
For this add the programme id after the settingname (SaveFolder, FileNameFormat and RunAfterCommand) in a new record in the table settings of store.db.

In the future on the basis of this change a combobox with programmes can be added in Main Options to be able to set SaveFolder, FileNameFormat and RunAfterCommand via the GUI.

This pull request is connected with Different options per subscription #202 .